### PR TITLE
Fix : page를 이동시킨 상태에서 카테고리 이동시 이전 page number로 리렌더링 되는 이슈 해결

### DIFF
--- a/src/components/Products/ProductList.products.js
+++ b/src/components/Products/ProductList.products.js
@@ -1,14 +1,13 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
-import useFetchProductList from '../../hooks/useFetchProductList.hook';
-import Product from './Product.products';
-import theme from '../../theme';
+import React, { useState } from "react";
+import styled from "styled-components";
+import useFetchProductList from "../../hooks/useFetchProductList.hook";
+import Product from "./Product.products";
+import theme from "../../theme";
 
-function ProductList({ category }) {
+function ProductList({ category, page, setPage }) {
   const { data } = useFetchProductList(category);
 
   const limit = 10;
-  const [page, setPage] = useState(1);
   const offset = (page - 1) * limit;
   const totalProductQty = data?.length;
   const pagesNum = Math.ceil(totalProductQty / limit);
@@ -26,7 +25,7 @@ function ProductList({ category }) {
               onClick={() => {
                 setPage(i + 1);
               }}
-              aria-current={page === i + 1 ? 'page' : null}
+              aria-current={page === i + 1 ? "page" : null}
             >
               {i + 1}
             </button>

--- a/src/pages/Products/Products.js
+++ b/src/pages/Products/Products.js
@@ -1,14 +1,15 @@
-import { useState } from 'react';
-import styled, { css } from 'styled-components';
-import Header from '../../components/Header/Header';
-import ProductList from '../../components/Products/ProductList.products';
-import useFetchCategoryData from '../../hooks/useFetchCategoryData.hook';
-import Footer from '../../components/Footer/Footer';
-import theme from '../../theme';
+import { useState } from "react";
+import styled, { css } from "styled-components";
+import Header from "../../components/Header/Header";
+import ProductList from "../../components/Products/ProductList.products";
+import useFetchCategoryData from "../../hooks/useFetchCategoryData.hook";
+import Footer from "../../components/Footer/Footer";
+import theme from "../../theme";
 
 function Products() {
   const { data } = useFetchCategoryData();
-  const [category, setCategory] = useState('Free');
+  const [page, setPage] = useState(1);
+  const [category, setCategory] = useState("Free");
 
   return (
     <>
@@ -24,9 +25,10 @@ function Products() {
                 return (
                   <Category
                     selected={category === el}
-                    key={index + ''}
+                    key={index + ""}
                     onClick={() => {
                       setCategory(el);
+                      setPage(1);
                     }}
                   >
                     {el}
@@ -37,7 +39,7 @@ function Products() {
           </CategoryWrap>
         </CategoryBox>
         <ProductListBox>
-          <ProductList category={category} />
+          <ProductList category={category} page={page} setPage={setPage} />
         </ProductListBox>
       </Container>
       <Footer />


### PR DESCRIPTION
### 구현 내용

#### 버그 fix
버그 detail : 
pagination 구현 후 이전 카테고리(ex. Strawberry)에서 onClick 이벤트로 페이지 이동 후, (ex. from page 1 to page 7) 다른 카테고리를
선택하여(ex. Live) productList를 리렌더링 시 이전 페이지 넘버를 유지시킨 상태로 이동하는 것을 확인했습니다.

수정한 코드 : Products/ProductList.products.js 에서 선언한 page state를 상위 컴포넌트인 Products.js 로 이동시켜 선언하고,
Products.js의 자식 컴포넌트인 ProductList.products.js에 props로 전달하여 setCategory함수 실행 후 setPage 함수를 실행하여 page
state를 초기화 시켜주었습니다.